### PR TITLE
Update README and examples to introduce new `colorClasses` and `style…

### DIFF
--- a/libs/react-forms/README.md
+++ b/libs/react-forms/README.md
@@ -78,7 +78,7 @@ Example:
 
 #### classes
 
-The `classes` object allows you to override CSS classes for different form components:
+The `classes` object allows you to override CSS classes for different form components. **Note: This is the legacy approach. For new projects, use `colorClasses` and `styleClasses` instead.**
 
 ```tsx
 <FormRenderer 
@@ -110,6 +110,52 @@ The `classes` object allows you to override CSS classes for different form compo
   }}
 />
 ```
+
+#### colorClasses and styleClasses (Recommended)
+
+For better organization and maintainability, you can now split CSS classes into two categories:
+
+- **`colorClasses`**: Controls colors, backgrounds, borders, and text colors
+- **`styleClasses`**: Controls spacing, sizing, positioning, borders, shadows, etc.
+
+```tsx
+<FormRenderer 
+  formJson={formDefinition}
+  settings={{
+    colorClasses: {
+      // Color-related classes
+      container: 'bg-blue-50',
+      header: 'bg-blue-100',
+      headerTitle: 'text-blue-800',
+      nextButton: 'bg-blue-600 hover:bg-blue-700 text-white',
+      previousButton: 'border-blue-300 text-blue-700',
+      fieldLabel: 'text-gray-700',
+      fieldInput: 'border-gray-300',
+      fieldError: 'text-red-500',
+      fieldHelperText: 'text-gray-500',
+    },
+    styleClasses: {
+      // Style and layout classes
+      container: 'w-full',
+      header: 'p-4 rounded-md',
+      headerTitle: 'text-2xl font-bold',
+      nextButton: 'px-4 py-2 rounded',
+      previousButton: 'px-4 py-2 border rounded',
+      field: 'mb-4',
+      fieldLabel: 'block text-sm font-medium mb-1',
+      fieldInput: 'w-full p-2 border rounded-md',
+      fieldError: 'mt-1 text-sm',
+      fieldHelperText: 'mt-1 text-sm',
+    }
+  }}
+/>
+```
+
+This approach provides several benefits:
+- **Better organization**: Separate color and layout concerns
+- **Easier theming**: Change colors without affecting layout
+- **Improved maintainability**: Clear separation of visual and structural styles
+- **Backward compatibility**: Legacy `classes` still works
 
 #### theme
 

--- a/libs/react-forms/src/examples/custom-styling-example.tsx
+++ b/libs/react-forms/src/examples/custom-styling-example.tsx
@@ -118,7 +118,43 @@ const bootstrapSettings = {
   },
 };
 
-// Example 3: Theme-based styling
+// Example 3: Split color and style classes (Recommended)
+const splitClassSettings = {
+  showFormSubmissions: true,
+  colorClasses: {
+    // Color-related classes
+    container: 'bg-blue-50',
+    header: 'bg-blue-100',
+    headerTitle: 'text-blue-800',
+    nextButton: 'bg-blue-600 hover:bg-blue-700 text-white',
+    previousButton: 'border-blue-300 text-blue-700',
+    fieldLabel: 'text-gray-700',
+    fieldInput: 'border-gray-300',
+    fieldError: 'text-red-500',
+    fieldHelperText: 'text-gray-500',
+  },
+  styleClasses: {
+    // Style and layout classes
+    container: 'w-full',
+    header: 'p-4 rounded-md',
+    headerTitle: 'text-2xl font-bold',
+    nextButton: 'px-6 py-2 rounded-md',
+    previousButton: 'px-6 py-2 border rounded-md',
+    field: 'mb-4',
+    fieldLabel: 'block text-sm font-medium mb-1',
+    fieldInput: 'w-full p-2 border rounded-md',
+    fieldError: 'mt-1 text-sm',
+    fieldHelperText: 'mt-1 text-sm',
+  },
+  texts: {
+    nextButton: 'Continue',
+    previousButton: 'Go Back',
+    submitButton: 'Send Form',
+    stepIndicator: 'Page {currentStep} of {totalSteps}',
+  },
+};
+
+// Example 4: Theme-based styling
 const themeSettings = {
   showFormSubmissions: true,
   theme: {
@@ -174,6 +210,8 @@ export const CustomStylingExample: React.FC = () => {
         return simpleOverrideSettings;
       case 'bootstrap':
         return bootstrapSettings;
+      case 'split':
+        return splitClassSettings;
       case 'theme':
         return themeSettings;
       default:
@@ -241,6 +279,16 @@ export const CustomStylingExample: React.FC = () => {
             }`}
           >
             Bootstrap Style
+          </button>
+          <button
+            onClick={() => setCurrentStyle('split')}
+            className={`px-3 py-2 rounded-md text-sm font-medium ${
+              currentStyle === 'split'
+                ? 'bg-indigo-600 text-white'
+                : 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50'
+            }`}
+          >
+            Split Classes (Recommended)
           </button>
           <button
             onClick={() => setCurrentStyle('theme')}

--- a/libs/react-forms/src/examples/index.ts
+++ b/libs/react-forms/src/examples/index.ts
@@ -9,4 +9,5 @@ export { ErrorMessagesExample } from './error-messages-example';
 export { WCAGErrorMessagesExample } from './wcag-error-messages-example';
 export { SubmittedValuesExample } from './submitted-values-example';
 export { CustomStylingExample } from './custom-styling-example';
+export { SplitClassesExample } from './split-classes-example';
 export { PageChangeEventExample } from './page-change-event-example';

--- a/libs/react-forms/src/examples/split-classes-example.tsx
+++ b/libs/react-forms/src/examples/split-classes-example.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { FormRenderer } from '../lib/molecules/FormRenderer';
+import { FormDefinition } from '../lib/interfaces/form-interfaces';
+
+// Simple form definition for testing
+const testForm: FormDefinition = {
+  app: {
+    title: 'Split Classes Example',
+    pages: [
+      {
+        id: 'page1',
+        title: 'Test Form',
+        components: [
+          {
+            id: 'name',
+            type: 'input',
+            label: 'Your Name',
+            validation: { required: true },
+            props: {
+              placeholder: 'Enter your name',
+              helperText: 'This is a test form to demonstrate split classes',
+            },
+          },
+          {
+            id: 'email',
+            type: 'input',
+            label: 'Email Address',
+            validation: { required: true },
+            props: {
+              inputType: 'email',
+              placeholder: 'Enter your email',
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+
+export const SplitClassesExample: React.FC = () => {
+  const handleSubmit = (formValues: Record<string, unknown>) => {
+    console.log('Split classes example submitted:', formValues);
+    alert('Form submitted! Check the console to see the submitted values.');
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto p-6">
+      <div className="mb-6 p-4 bg-green-50 border border-green-200 rounded-md">
+        <h3 className="text-lg font-medium text-green-800 mb-2">
+          Split Classes Example
+        </h3>
+        <p className="text-green-700 text-sm">
+          This example demonstrates the new split class structure with separate
+          color and style classes.
+        </p>
+      </div>
+
+      <FormRenderer
+        formJson={testForm}
+        onSubmit={handleSubmit}
+        settings={{
+          showFormSubmissions: true,
+          colorClasses: {
+            // Color-related classes
+            container: 'bg-green-50',
+            header: 'bg-green-100',
+            headerTitle: 'text-green-800',
+            nextButton: 'bg-green-600 hover:bg-green-700 text-white',
+            previousButton: 'border-green-300 text-green-700',
+            fieldLabel: 'text-gray-800',
+            fieldInput: 'border-green-300 focus:border-green-500',
+            fieldError: 'text-red-600',
+            fieldHelperText: 'text-green-600',
+          },
+          styleClasses: {
+            // Style and layout classes
+            container: 'w-full',
+            header: 'p-4 rounded-lg',
+            headerTitle: 'text-2xl font-bold',
+            nextButton: 'px-6 py-3 rounded-lg font-medium',
+            previousButton: 'px-6 py-3 border rounded-lg font-medium',
+            field: 'mb-6',
+            fieldLabel: 'block text-sm font-semibold mb-2',
+            fieldInput:
+              'w-full p-3 border rounded-lg focus:ring-2 focus:ring-green-200',
+            fieldError: 'mt-2 text-sm',
+            fieldHelperText: 'mt-2 text-sm',
+          },
+          texts: {
+            nextButton: 'Submit Form',
+            submitButton: 'Submit Form',
+          },
+        }}
+      />
+    </div>
+  );
+};

--- a/libs/react-forms/src/lib/config/default-classes.ts
+++ b/libs/react-forms/src/lib/config/default-classes.ts
@@ -1,0 +1,145 @@
+import {
+  FormRendererColorClasses,
+  FormRendererStyleClasses,
+} from '../interfaces/form-interfaces';
+
+/**
+ * Default color classes for form components
+ * These classes control colors, backgrounds, borders, and text colors
+ */
+export const defaultColorClasses: FormRendererColorClasses = {
+  // Layout Colors
+  container: '',
+  header: 'bg-indigo-50',
+  headerTitle: 'text-indigo-700',
+  page: '',
+  pageTitle: '',
+
+  // Navigation Colors
+  stepIndicator: 'bg-gray-200',
+  stepIndicatorItem: 'text-gray-700',
+  stepIndicatorActive: 'bg-indigo-600',
+  navigationButtons: '',
+  nextButton: 'bg-indigo-600 hover:bg-indigo-700 text-white',
+  previousButton: 'border-indigo-300 text-indigo-700',
+
+  // Form Field Colors
+  field: '',
+  fieldLabel: 'text-gray-700',
+  fieldInput: 'border-gray-300',
+  fieldTextarea: 'border-gray-300',
+  fieldSelect: 'border-gray-300 bg-white',
+  fieldCheckbox: 'text-indigo-600 focus:ring-indigo-500',
+  fieldRadio: 'text-indigo-600 focus:ring-indigo-500',
+  fieldDate: 'border-gray-300',
+  fieldSlider: 'bg-gray-200',
+  fieldText: 'text-gray-700',
+  fieldError: 'text-red-500',
+  fieldHelperText: 'text-gray-500',
+
+  // Special Component Colors
+  confirmationField: '',
+  arrayField: '',
+  arrayItem: '',
+  arrayAddButton: 'bg-indigo-600 hover:bg-indigo-700 text-white',
+  arrayRemoveButton: 'bg-red-600 hover:bg-red-700 text-white',
+
+  // Submissions Colors
+  submissionsContainer: '',
+  submissionsTitle: '',
+  submissionsData: 'bg-gray-50',
+
+  // Thank You Page Colors
+  thankYouContainer: 'bg-green-50',
+  thankYouTitle: 'text-green-700',
+  thankYouMessage: 'text-gray-700',
+  thankYouButton: 'bg-indigo-600 hover:bg-indigo-700 text-white',
+};
+
+/**
+ * Default style classes for form components
+ * These classes control spacing, sizing, positioning, borders, shadows, etc.
+ */
+export const defaultStyleClasses: FormRendererStyleClasses = {
+  // Layout Styles
+  container: 'w-full',
+  header: 'p-4 rounded-md',
+  headerTitle: 'text-2xl font-bold',
+  page: 'bg-white rounded-md shadow-sm p-6',
+  pageTitle: 'text-xl font-bold mb-6',
+
+  // Navigation Styles
+  stepIndicator: 'w-2/3 rounded-full h-2.5',
+  stepIndicatorItem: 'text-sm font-medium',
+  stepIndicatorActive: 'h-2.5 rounded-full',
+  navigationButtons: 'mt-6 flex justify-between',
+  nextButton: 'px-4 py-2 rounded-md',
+  previousButton: 'px-4 py-2 border rounded-md',
+
+  // Form Field Styles
+  field: 'mb-4',
+  fieldLabel: 'block text-sm font-medium mb-1',
+  fieldInput: 'w-full p-2 border rounded-md',
+  fieldTextarea: 'w-full p-2 border rounded-md',
+  fieldSelect: 'w-full p-2 border rounded-md',
+  fieldCheckbox: 'h-4 w-4',
+  fieldRadio: 'h-4 w-4',
+  fieldDate: 'w-full p-2 border rounded-md',
+  fieldSlider: 'relative h-6 rounded-lg cursor-pointer',
+  fieldText: '',
+  fieldError: 'mt-1 text-sm',
+  fieldHelperText: 'mt-1 text-sm',
+
+  // Special Component Styles
+  confirmationField: '',
+  arrayField: '',
+  arrayItem: '',
+  arrayAddButton: 'px-4 py-2 rounded-md',
+  arrayRemoveButton: 'px-4 py-2 rounded-md',
+
+  // Submissions Styles
+  submissionsContainer: 'mt-8 border-t pt-6',
+  submissionsTitle: 'text-lg font-medium mb-4',
+  submissionsData: 'p-4 rounded-md',
+
+  // Thank You Page Styles
+  thankYouContainer: 'p-4 rounded-md',
+  thankYouTitle: 'text-2xl font-bold',
+  thankYouMessage: 'text-lg leading-relaxed',
+  thankYouButton: 'px-6 py-2 rounded-md transition-colors',
+};
+
+/**
+ * Error state color classes
+ * Applied when form fields have validation errors
+ */
+export const errorColorClasses: Partial<FormRendererColorClasses> = {
+  fieldInput: 'border-red-500',
+  fieldTextarea: 'border-red-500',
+  fieldSelect: 'border-red-500',
+  fieldDate: 'border-red-500',
+};
+
+/**
+ * Disabled state color classes
+ * Applied when form fields are disabled
+ */
+export const disabledColorClasses: Partial<FormRendererColorClasses> = {
+  fieldInput: 'bg-gray-100 cursor-not-allowed',
+  fieldTextarea: 'bg-gray-100 cursor-not-allowed',
+  fieldSelect: 'bg-gray-100 cursor-not-allowed',
+  fieldDate: 'bg-gray-100 cursor-not-allowed',
+  fieldCheckbox: 'cursor-not-allowed opacity-50',
+  fieldRadio: 'cursor-not-allowed opacity-50',
+};
+
+/**
+ * Read-only state color classes
+ * Applied when form fields are read-only
+ */
+export const readOnlyColorClasses: Partial<FormRendererColorClasses> = {
+  fieldInput: 'bg-gray-50 cursor-not-allowed text-gray-900',
+  fieldTextarea: 'bg-gray-50 cursor-not-allowed text-gray-900',
+  fieldSelect: 'bg-gray-50 cursor-not-allowed text-gray-900',
+  fieldDate: 'bg-gray-50 cursor-not-allowed text-gray-900',
+};

--- a/libs/react-forms/src/lib/interfaces/form-interfaces.ts
+++ b/libs/react-forms/src/lib/interfaces/form-interfaces.ts
@@ -170,6 +170,116 @@ export interface FormRendererTexts {
   noContentInSection?: string; // Default: "No content in this section"
 }
 
+/**
+ * Color-related CSS classes for form components
+ * These classes control colors, backgrounds, borders, and text colors
+ */
+export interface FormRendererColorClasses {
+  // Layout Colors
+  container?: string;
+  header?: string;
+  headerTitle?: string;
+  page?: string;
+  pageTitle?: string;
+
+  // Navigation Colors
+  stepIndicator?: string;
+  stepIndicatorItem?: string;
+  stepIndicatorActive?: string;
+  navigationButtons?: string;
+  nextButton?: string;
+  previousButton?: string;
+
+  // Form Field Colors
+  field?: string;
+  fieldLabel?: string;
+  fieldInput?: string;
+  fieldTextarea?: string;
+  fieldSelect?: string;
+  fieldCheckbox?: string;
+  fieldRadio?: string;
+  fieldDate?: string;
+  fieldSlider?: string;
+  fieldText?: string;
+  fieldError?: string;
+  fieldHelperText?: string;
+
+  // Special Component Colors
+  confirmationField?: string;
+  arrayField?: string;
+  arrayItem?: string;
+  arrayAddButton?: string;
+  arrayRemoveButton?: string;
+
+  // Submissions Colors
+  submissionsContainer?: string;
+  submissionsTitle?: string;
+  submissionsData?: string;
+
+  // Thank You Page Colors
+  thankYouContainer?: string;
+  thankYouTitle?: string;
+  thankYouMessage?: string;
+  thankYouButton?: string;
+}
+
+/**
+ * Style and layout CSS classes for form components
+ * These classes control spacing, sizing, positioning, borders, shadows, etc.
+ */
+export interface FormRendererStyleClasses {
+  // Layout Styles
+  container?: string;
+  header?: string;
+  headerTitle?: string;
+  page?: string;
+  pageTitle?: string;
+
+  // Navigation Styles
+  stepIndicator?: string;
+  stepIndicatorItem?: string;
+  stepIndicatorActive?: string;
+  navigationButtons?: string;
+  nextButton?: string;
+  previousButton?: string;
+
+  // Form Field Styles
+  field?: string;
+  fieldLabel?: string;
+  fieldInput?: string;
+  fieldTextarea?: string;
+  fieldSelect?: string;
+  fieldCheckbox?: string;
+  fieldRadio?: string;
+  fieldDate?: string;
+  fieldSlider?: string;
+  fieldText?: string;
+  fieldError?: string;
+  fieldHelperText?: string;
+
+  // Special Component Styles
+  confirmationField?: string;
+  arrayField?: string;
+  arrayItem?: string;
+  arrayAddButton?: string;
+  arrayRemoveButton?: string;
+
+  // Submissions Styles
+  submissionsContainer?: string;
+  submissionsTitle?: string;
+  submissionsData?: string;
+
+  // Thank You Page Styles
+  thankYouContainer?: string;
+  thankYouTitle?: string;
+  thankYouMessage?: string;
+  thankYouButton?: string;
+}
+
+/**
+ * @deprecated Use FormRendererColorClasses and FormRendererStyleClasses instead
+ * Legacy interface for backward compatibility
+ */
 export interface FormRendererClasses {
   // Layout
   container?: string;
@@ -219,9 +329,33 @@ export interface FormRendererClasses {
   thankYouButton?: string;
 }
 
+/**
+ * Field component classes interface
+ * Used by individual field components
+ */
+export interface FieldClasses {
+  field?: string;
+  fieldLabel?: string;
+  fieldInput?: string;
+  fieldTextarea?: string;
+  fieldSelect?: string;
+  fieldCheckbox?: string;
+  fieldRadio?: string;
+  fieldDate?: string;
+  fieldSlider?: string;
+  fieldText?: string;
+  fieldError?: string;
+  fieldHelperText?: string;
+}
+
 export interface FormRendererSettings {
   showFormSubmissions?: boolean;
+  /** @deprecated Use colorClasses and styleClasses instead */
   classes?: FormRendererClasses;
+  /** Color-related CSS classes for form components */
+  colorClasses?: FormRendererColorClasses;
+  /** Style and layout CSS classes for form components */
+  styleClasses?: FormRendererStyleClasses;
   theme?: FormRendererTheme;
   texts?: FormRendererTexts;
 }

--- a/libs/react-forms/src/lib/molecules/FormRenderer.tsx
+++ b/libs/react-forms/src/lib/molecules/FormRenderer.tsx
@@ -35,7 +35,17 @@ import {
   FormRendererSettings as MultiLanguageFormRendererSettings,
 } from '../interfaces/multi-language-interfaces';
 import { TranslationService } from '../services/translation-service';
-import { getClassNames, mergeClassNames, getText } from '../utils/class-utils';
+import {
+  getClassNames,
+  mergeClassNames,
+  getText,
+  getClassNamesWithColorAndStyle,
+  convertToFieldClasses,
+} from '../utils/class-utils';
+import {
+  defaultColorClasses,
+  defaultStyleClasses,
+} from '../config/default-classes';
 import {
   calculateLogicalPageOrder,
   getLogicalPageIndex,
@@ -44,6 +54,41 @@ import {
   isLastLogicalPage,
   LogicalPageOrder,
 } from '../utils/page-ordering';
+
+/**
+ * Helper function to merge color and style classes with legacy support
+ */
+const getMergedClasses = (
+  componentKey: keyof typeof defaultColorClasses,
+  settings: any
+) => {
+  // Use new color and style classes if available
+  if (settings.colorClasses || settings.styleClasses) {
+    const colorClass =
+      settings.colorClasses?.[componentKey] ||
+      defaultColorClasses[componentKey] ||
+      '';
+    const styleClass =
+      settings.styleClasses?.[componentKey] ||
+      defaultStyleClasses[componentKey] ||
+      '';
+    return getClassNamesWithColorAndStyle(colorClass, styleClass);
+  }
+
+  // Fallback to legacy classes
+  return settings.classes?.[componentKey] || '';
+};
+
+/**
+ * Helper function to get field classes with new structure support
+ */
+const getFieldClasses = (settings: any) => {
+  return convertToFieldClasses(
+    settings.colorClasses,
+    settings.styleClasses,
+    settings.classes
+  );
+};
 
 export const FormRenderer: React.FC<FormRendererProps> = ({
   formJson,
@@ -1082,16 +1127,16 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
 
     return (
       <div
-        className={getClassNames(
-          'mb-4 flex items-center justify-between',
-          settings.classes?.stepIndicator
-        )}
+        className={
+          getMergedClasses('stepIndicator', settings) ||
+          'mb-4 flex items-center justify-between'
+        }
       >
         <div
-          className={getClassNames(
-            'text-sm font-medium text-gray-700',
-            settings.classes?.stepIndicatorItem
-          )}
+          className={
+            getMergedClasses('stepIndicatorItem', settings) ||
+            'text-sm font-medium text-gray-700'
+          }
         >
           {translationService.translateUI('stepIndicator', {
             currentStep,
@@ -1099,16 +1144,16 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
           })}
         </div>
         <div
-          className={getClassNames(
-            'w-2/3 bg-gray-200 rounded-full h-2.5',
-            settings.classes?.stepIndicator
-          )}
+          className={
+            getMergedClasses('stepIndicator', settings) ||
+            'w-2/3 bg-gray-200 rounded-full h-2.5'
+          }
         >
           <div
-            className={getClassNames(
-              'bg-indigo-600 h-2.5 rounded-full',
-              settings.classes?.stepIndicatorActive
-            )}
+            className={
+              getMergedClasses('stepIndicatorActive', settings) ||
+              'bg-indigo-600 h-2.5 rounded-full'
+            }
             style={{ width: `${(currentStep / totalSteps) * 100}%` }}
           ></div>
         </div>
@@ -1150,21 +1195,21 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
 
     return (
       <div
-        className={getClassNames(
-          'mt-6 flex justify-between',
-          settings.classes?.navigationButtons
-        )}
+        className={
+          getMergedClasses('navigationButtons', settings) ||
+          'mt-6 flex justify-between'
+        }
       >
         <button
           type="button"
-          className={getClassNames(
+          className={
+            getMergedClasses('previousButton', settings) ||
             `px-4 py-2 border border-indigo-300 text-indigo-700 rounded-md ${
               currentStep === 1
                 ? 'opacity-50 cursor-not-allowed'
                 : 'hover:bg-indigo-50'
-            }`,
-            settings.classes?.previousButton
-          )}
+            }`
+          }
           disabled={currentStep === 1}
           onClick={handlePrevious}
         >
@@ -1172,10 +1217,10 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
         </button>
         <button
           type="button"
-          className={getClassNames(
-            'px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700',
-            settings.classes?.nextButton
-          )}
+          className={
+            getMergedClasses('nextButton', settings) ||
+            'px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700'
+          }
           onClick={handleNext}
         >
           {nextButtonText}
@@ -1578,22 +1623,13 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
                     return acc;
                   }, {} as Record<string, string | undefined>),
                 }}
-                classes={{
-                  field: settings.classes?.field,
-                  fieldLabel: settings.classes?.fieldLabel,
-                  fieldError: settings.classes?.fieldError,
-                  fieldHelperText: settings.classes?.fieldHelperText,
-                }}
+                classes={getFieldClasses(settings)}
               >
                 <TextFormField
                   fieldId={prefixedFieldId}
                   label={translatedLabel}
                   props={processPropsWithTemplates(translatedProps)}
-                  classes={{
-                    field: settings.classes?.field,
-                    fieldLabel: settings.classes?.fieldLabel,
-                    fieldText: settings.classes?.fieldText,
-                  }}
+                  classes={getFieldClasses(settings)}
                 />
               </FormExpressionField>
             );
@@ -1605,11 +1641,7 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
                 label={translatedLabel}
                 props={translatedProps}
                 formValues={formValues}
-                classes={{
-                  field: settings.classes?.field,
-                  fieldLabel: settings.classes?.fieldLabel,
-                  fieldText: settings.classes?.fieldText,
-                }}
+                classes={getFieldClasses(settings)}
               />
             );
           }
@@ -1634,13 +1666,7 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
               showError={showError}
               validationErrors={validationErrors[fieldId] || []}
               disabled={disabled}
-              classes={{
-                field: settings.classes?.field,
-                fieldLabel: settings.classes?.fieldLabel,
-                fieldInput: settings.classes?.fieldInput,
-                fieldError: settings.classes?.fieldError,
-                fieldHelperText: settings.classes?.fieldHelperText,
-              }}
+              classes={getFieldClasses(settings)}
             />
           );
 
@@ -1664,13 +1690,7 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
               showError={showError}
               validationErrors={validationErrors[fieldId] || []}
               disabled={disabled}
-              classes={{
-                field: settings.classes?.field,
-                fieldLabel: settings.classes?.fieldLabel,
-                fieldTextarea: settings.classes?.fieldTextarea,
-                fieldError: settings.classes?.fieldError,
-                fieldHelperText: settings.classes?.fieldHelperText,
-              }}
+              classes={getFieldClasses(settings)}
             />
           );
 
@@ -1690,13 +1710,7 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
               showError={showError}
               validationErrors={validationErrors[fieldId] || []}
               disabled={disabled}
-              classes={{
-                field: settings.classes?.field,
-                fieldLabel: settings.classes?.fieldLabel,
-                fieldRadio: settings.classes?.fieldRadio,
-                fieldError: settings.classes?.fieldError,
-                fieldHelperText: settings.classes?.fieldHelperText,
-              }}
+              classes={getFieldClasses(settings)}
             />
           );
 
@@ -1713,13 +1727,7 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
               showError={showError}
               validationErrors={validationErrors[fieldId] || []}
               disabled={disabled}
-              classes={{
-                field: settings.classes?.field,
-                fieldLabel: settings.classes?.fieldLabel,
-                fieldCheckbox: settings.classes?.fieldCheckbox,
-                fieldError: settings.classes?.fieldError,
-                fieldHelperText: settings.classes?.fieldHelperText,
-              }}
+              classes={getFieldClasses(settings)}
             />
           );
 
@@ -1740,13 +1748,7 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
               showError={showError}
               validationErrors={validationErrors[fieldId] || []}
               disabled={disabled}
-              classes={{
-                field: settings.classes?.field,
-                fieldLabel: settings.classes?.fieldLabel,
-                fieldSelect: settings.classes?.fieldSelect,
-                fieldError: settings.classes?.fieldError,
-                fieldHelperText: settings.classes?.fieldHelperText,
-              }}
+              classes={getFieldClasses(settings)}
             />
           );
 
@@ -1767,13 +1769,7 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
               showError={showError}
               validationErrors={validationErrors[fieldId] || []}
               disabled={disabled}
-              classes={{
-                field: settings.classes?.field,
-                fieldLabel: settings.classes?.fieldLabel,
-                fieldDate: settings.classes?.fieldDate,
-                fieldError: settings.classes?.fieldError,
-                fieldHelperText: settings.classes?.fieldHelperText,
-              }}
+              classes={getFieldClasses(settings)}
             />
           );
 
@@ -1812,12 +1808,7 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
               label={label}
               children={component.children}
               renderComponent={renderComponent}
-              classes={{
-                field: settings.classes?.field,
-                fieldLabel: settings.classes?.fieldLabel,
-                noContentText:
-                  translationService.translateUI('noContentInSection'),
-              }}
+              classes={getFieldClasses(settings)}
             />
           );
 
@@ -1937,13 +1928,7 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
               showError={showError}
               validationErrors={validationErrors[fieldId] || []}
               disabled={disabled}
-              classes={{
-                field: settings.classes?.field,
-                fieldLabel: settings.classes?.fieldLabel,
-                fieldSlider: settings.classes?.fieldSlider,
-                fieldError: settings.classes?.fieldError,
-                fieldHelperText: settings.classes?.fieldHelperText,
-              }}
+              classes={getFieldClasses(settings)}
             />
           );
 
@@ -2063,13 +2048,7 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
             // Array item field props
             isArrayItem={true}
             arrayItemChangeHandler={handleArrayItemChange}
-            classes={{
-              field: settings.classes?.field,
-              fieldLabel: settings.classes?.fieldLabel,
-              fieldInput: settings.classes?.fieldInput,
-              fieldError: settings.classes?.fieldError,
-              fieldHelperText: settings.classes?.fieldHelperText,
-            }}
+            classes={getFieldClasses(settings)}
           />
         );
 
@@ -2091,13 +2070,7 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
             showError={showError}
             validationErrors={validationErrors[fieldId] || []}
             disabled={disabled}
-            classes={{
-              field: settings.classes?.field,
-              fieldLabel: settings.classes?.fieldLabel,
-              fieldTextarea: settings.classes?.fieldTextarea,
-              fieldError: settings.classes?.fieldError,
-              fieldHelperText: settings.classes?.fieldHelperText,
-            }}
+            classes={getFieldClasses(settings)}
           />
         );
 
@@ -2116,13 +2089,7 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
             showError={showError}
             validationErrors={validationErrors[fieldId] || []}
             disabled={disabled}
-            classes={{
-              field: settings.classes?.field,
-              fieldLabel: settings.classes?.fieldLabel,
-              fieldSelect: settings.classes?.fieldSelect,
-              fieldError: settings.classes?.fieldError,
-              fieldHelperText: settings.classes?.fieldHelperText,
-            }}
+            classes={getFieldClasses(settings)}
           />
         );
 
@@ -2140,13 +2107,7 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
             showError={showError}
             validationErrors={validationErrors[fieldId] || []}
             disabled={disabled}
-            classes={{
-              field: settings.classes?.field,
-              fieldLabel: settings.classes?.fieldLabel,
-              fieldRadio: settings.classes?.fieldRadio,
-              fieldError: settings.classes?.fieldError,
-              fieldHelperText: settings.classes?.fieldHelperText,
-            }}
+            classes={getFieldClasses(settings)}
           />
         );
 
@@ -2165,13 +2126,7 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
             showError={showError}
             validationErrors={validationErrors[fieldId] || []}
             disabled={disabled}
-            classes={{
-              field: settings.classes?.field,
-              fieldLabel: settings.classes?.fieldLabel,
-              fieldCheckbox: settings.classes?.fieldCheckbox,
-              fieldError: settings.classes?.fieldError,
-              fieldHelperText: settings.classes?.fieldHelperText,
-            }}
+            classes={getFieldClasses(settings)}
           />
         );
 
@@ -2190,13 +2145,7 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
             showError={showError}
             validationErrors={validationErrors[fieldId] || []}
             disabled={disabled}
-            classes={{
-              field: settings.classes?.field,
-              fieldLabel: settings.classes?.fieldLabel,
-              fieldDate: settings.classes?.fieldDate,
-              fieldError: settings.classes?.fieldError,
-              fieldHelperText: settings.classes?.fieldHelperText,
-            }}
+            classes={getFieldClasses(settings)}
           />
         );
 
@@ -2224,13 +2173,7 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
             showError={showError}
             validationErrors={validationErrors[fieldId] || []}
             disabled={disabled}
-            classes={{
-              field: settings.classes?.field,
-              fieldLabel: settings.classes?.fieldLabel,
-              fieldSlider: settings.classes?.fieldSlider,
-              fieldError: settings.classes?.fieldError,
-              fieldHelperText: settings.classes?.fieldHelperText,
-            }}
+            classes={getFieldClasses(settings)}
           />
         );
 
@@ -2345,13 +2288,13 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
         <div
           className={getClassNames(
             'mb-4 bg-green-50 p-4 rounded-md',
-            settings.classes?.thankYouContainer
+            getMergedClasses('thankYouContainer', settings)
           )}
         >
           <h1
             className={getClassNames(
               'text-2xl font-bold text-green-700',
-              settings.classes?.thankYouTitle
+              getMergedClasses('thankYouTitle', settings)
             )}
           >
             {translationService.translateApp('title', thankYouPage.title) ||
@@ -2362,7 +2305,7 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
         <div
           className={getClassNames(
             'bg-white rounded-md shadow-sm p-6',
-            settings.classes?.thankYouContainer
+            getMergedClasses('thankYouContainer', settings)
           )}
         >
           {thankYouPage.message && (
@@ -2370,7 +2313,7 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
               <p
                 className={getClassNames(
                   'text-lg text-gray-700 leading-relaxed',
-                  settings.classes?.thankYouMessage
+                  getMergedClasses('thankYouMessage', settings)
                 )}
               >
                 {thankYouPage.message}
@@ -2393,7 +2336,7 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
                 onClick={() => handleThankYouAction('restart')}
                 className={getClassNames(
                   'px-6 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition-colors',
-                  settings.classes?.thankYouButton
+                  getMergedClasses('thankYouButton', settings)
                 )}
               >
                 {translationService.translateUI('restartButton')}
@@ -2447,13 +2390,13 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
         key={page.id}
         className={getClassNames(
           'bg-white rounded-md shadow-sm p-6',
-          settings.classes?.page
+          getMergedClasses('page', settings)
         )}
       >
         <h2
           className={getClassNames(
             'text-xl font-bold mb-6',
-            settings.classes?.pageTitle
+            getMergedClasses('pageTitle', settings)
           )}
         >
           {translationService.translatePage(
@@ -2528,7 +2471,7 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
       }}
     >
       <div
-        className={getClassNames('w-full', settings.classes?.container)}
+        className={getMergedClasses('container', settings) || 'w-full'}
         style={themeStyles}
       >
         {/* Check for invalid form data */}
@@ -2541,16 +2484,16 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
         ) : (
           <>
             <div
-              className={getClassNames(
-                'mb-4 bg-indigo-50 p-4 rounded-md',
-                settings.classes?.header
-              )}
+              className={
+                getMergedClasses('header', settings) ||
+                'mb-4 bg-indigo-50 p-4 rounded-md'
+              }
             >
               <h1
-                className={getClassNames(
-                  'text-2xl font-bold text-indigo-700',
-                  settings.classes?.headerTitle
-                )}
+                className={
+                  getMergedClasses('headerTitle', settings) ||
+                  'text-2xl font-bold text-indigo-700'
+                }
               >
                 {translationService.translateApp('title', formJson.app.title)}
               </h1>
@@ -2560,7 +2503,7 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
                   <div
                     className={getClassNames(
                       'mt-2 text-sm text-indigo-500',
-                      settings.classes?.header
+                      getMergedClasses('header', settings)
                     )}
                   >
                     {translationService.translateUI('multiPageInfo', {
@@ -2576,13 +2519,13 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
               <div
                 className={getClassNames(
                   'mt-8 border-t pt-6',
-                  settings.classes?.submissionsContainer
+                  getMergedClasses('submissionsContainer', settings)
                 )}
               >
                 <h3
                   className={getClassNames(
                     'text-lg font-medium mb-4',
-                    settings.classes?.submissionsTitle
+                    getMergedClasses('submissionsTitle', settings)
                   )}
                 >
                   {translationService.translateUI('submissionsTitle')}
@@ -2590,7 +2533,7 @@ export const FormRenderer: React.FC<FormRendererProps> = ({
                 <div
                   className={getClassNames(
                     'bg-gray-50 p-4 rounded-md',
-                    settings.classes?.submissionsData
+                    getMergedClasses('submissionsData', settings)
                   )}
                 >
                   {renderSubmissionData()}

--- a/libs/react-forms/src/lib/utils/class-utils.ts
+++ b/libs/react-forms/src/lib/utils/class-utils.ts
@@ -1,3 +1,9 @@
+import {
+  FormRendererColorClasses,
+  FormRendererStyleClasses,
+  FieldClasses,
+} from '../interfaces/form-interfaces';
+
 /**
  * Utility function to get class names with optional overrides
  * @param baseClasses - Default Tailwind classes
@@ -9,6 +15,48 @@ export const getClassNames = (
   overrideClasses?: string
 ): string => {
   return overrideClasses || baseClasses;
+};
+
+/**
+ * Utility function to merge color and style classes
+ * @param colorClasses - Color-related classes (backgrounds, text colors, borders)
+ * @param styleClasses - Style and layout classes (spacing, sizing, positioning)
+ * @param additionalClasses - Additional classes to append
+ * @returns Combined class string
+ */
+export const mergeColorAndStyleClasses = (
+  colorClasses: string,
+  styleClasses: string,
+  additionalClasses?: string
+): string => {
+  const combined = `${colorClasses} ${styleClasses}`.trim();
+  if (!additionalClasses) return combined;
+  return `${combined} ${additionalClasses}`;
+};
+
+/**
+ * Utility function to get class names with color and style overrides
+ * @param defaultColorClasses - Default color classes
+ * @param defaultStyleClasses - Default style classes
+ * @param colorOverride - Optional color class override
+ * @param styleOverride - Optional style class override
+ * @param additionalClasses - Additional classes to append
+ * @returns Combined class string
+ */
+export const getClassNamesWithColorAndStyle = (
+  defaultColorClasses: string,
+  defaultStyleClasses: string,
+  colorOverride?: string,
+  styleOverride?: string,
+  additionalClasses?: string
+): string => {
+  const colorClasses = colorOverride || defaultColorClasses;
+  const styleClasses = styleOverride || defaultStyleClasses;
+  return mergeColorAndStyleClasses(
+    colorClasses,
+    styleClasses,
+    additionalClasses
+  );
 };
 
 /**
@@ -38,6 +86,65 @@ export const conditionalClassNames = (
   conditionalClasses: string
 ): string => {
   return condition ? `${baseClasses} ${conditionalClasses}` : baseClasses;
+};
+
+/**
+ * Helper function to convert color and style classes to field classes
+ * @param colorClasses - Color classes from settings
+ * @param styleClasses - Style classes from settings
+ * @param legacyClasses - Legacy classes for backward compatibility
+ * @returns FieldClasses object
+ */
+export const convertToFieldClasses = (
+  colorClasses?: FormRendererColorClasses,
+  styleClasses?: FormRendererStyleClasses,
+  legacyClasses?: any
+): FieldClasses => {
+  // If legacy classes are provided, use them for backward compatibility
+  if (legacyClasses) {
+    return {
+      field: legacyClasses.field,
+      fieldLabel: legacyClasses.fieldLabel,
+      fieldInput: legacyClasses.fieldInput,
+      fieldTextarea: legacyClasses.fieldTextarea,
+      fieldSelect: legacyClasses.fieldSelect,
+      fieldCheckbox: legacyClasses.fieldCheckbox,
+      fieldRadio: legacyClasses.fieldRadio,
+      fieldDate: legacyClasses.fieldDate,
+      fieldSlider: legacyClasses.fieldSlider,
+      fieldText: legacyClasses.fieldText,
+      fieldError: legacyClasses.fieldError,
+      fieldHelperText: legacyClasses.fieldHelperText,
+    };
+  }
+
+  // Convert new class structure to field classes
+  const fieldClasses: FieldClasses = {};
+
+  if (colorClasses || styleClasses) {
+    const fieldKeys: (keyof FieldClasses)[] = [
+      'field',
+      'fieldLabel',
+      'fieldInput',
+      'fieldTextarea',
+      'fieldSelect',
+      'fieldCheckbox',
+      'fieldRadio',
+      'fieldDate',
+      'fieldSlider',
+      'fieldText',
+      'fieldError',
+      'fieldHelperText',
+    ];
+
+    fieldKeys.forEach((key) => {
+      const colorClass = colorClasses?.[key] || '';
+      const styleClass = styleClasses?.[key] || '';
+      fieldClasses[key] = mergeColorAndStyleClasses(colorClass, styleClass);
+    });
+  }
+
+  return fieldClasses;
 };
 
 /**


### PR DESCRIPTION
…Classes` for improved CSS management

- Updated README to highlight the legacy `classes` approach and recommend using `colorClasses` and `styleClasses` for new projects.
- Added a new example (`SplitClassesExample`) demonstrating the use of the new class structure.
- Refactored existing examples to incorporate the new class system, enhancing organization and maintainability.
- Introduced default color and style classes for better customization options in form components.